### PR TITLE
Prevent error if event.multiValueHeaders is null

### DIFF
--- a/src/event-mappings/utils.js
+++ b/src/event-mappings/utils.js
@@ -16,7 +16,7 @@ function mapEventToHttpRequest ({
 }) {
   if (!headers) {
     headers = {}
-    Object.entries(event.multiValueHeaders).forEach(([headerKey, headerValue]) => {
+    Object.entries(event.multiValueHeaders || {}).forEach(([headerKey, headerValue]) => {
       headers[headerKey] = headerValue.join(',')
     })
   }


### PR DESCRIPTION
*Description of changes:*

Since `event.multiValueHeaders` can be `null` in many cases, this fix prevents an error trying to call `Object.entries` on a null object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
