### PR TITLE
fix(Config): update runtime node version to be compatible with AWS

### DIFF
--- a/examples/basic-starter/cloudformation.yaml
+++ b/examples/basic-starter/cloudformation.yaml
@@ -57,7 +57,7 @@ Resources:
       Handler: lambda.handler
       MemorySize: 1024
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 30
       Events:
         ProxyApiRoot:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The settings of the Basic Example directory specify a node version that AWS Stacks no longer support. See the following screenshot:

<img width="1015" alt="Screen Shot 2020-08-08 at 10 28 30 AM" src="https://user-images.githubusercontent.com/7477387/89716957-60ac0800-d966-11ea-86d3-9bdebc321dc8.png">

This change updates the node version to be compatible with AWS so that developers who use the Basic Example can get started more seamlessly. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

*Please ensure all pull requests are made against the `develop` branch.*

It appears the `develop` branch is well behind the master and appears to have been unused for some time. For that reason, I am basing these changes against `master`. I'll be happy to change the base if that's an active request by the maintainers.